### PR TITLE
fix:  koa's redirect function not available

### DIFF
--- a/src/inject.ts
+++ b/src/inject.ts
@@ -37,7 +37,7 @@ export async function Handler(app: Koatty, ctx: KoattyContext, ctl: any, method:
   }
   // method
   const res = await ctl[method](...args);
-  ctx.body = res;
+  ctx.body = ctx.body || res;
 }
 
 /**


### PR DESCRIPTION
```typescript
@GetMapping('/baidu')
async baidu(): Promise<any> {
    this.ctx.redirect("https://www.baidu.com/")
    return 
}
```
koa.redirect  has set this.body ,but koatty will cover it to null.